### PR TITLE
성인/키즈 메뉴 추가

### DIFF
--- a/src/component/Category/Category.js
+++ b/src/component/Category/Category.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import styled from 'styled-components';
+import TestImg1 from '../../styles/images/CategoryTest1.svg';
+import Bar from '../../styles/images/CategoryBar.svg';
+import GreenBar from '../../styles/images/GreenBar.svg';
+
+const Wrapper = styled.div`
+    display:flex;
+    flex-direction: column;
+    width:100%;
+`;
+
+const Grid = styled.div`
+    display : grid;
+    width : 100%;
+    grid-template-rows: repeat(1, 1fr);
+    grid-template-columns: repeat(2, 1fr);
+    margin-top : 1rem;
+    align-self : center;
+    justify-self : center;
+    margin-botton : 1rem;
+`;
+
+const Container = styled.div`
+    display : flex;
+    width : 100%;
+    justify-content : center;
+    align-items : center;
+    flex-direction : column;
+`;
+
+const Item = styled.div`
+    width: 59px;
+    height: 22px;
+    background-size:cover;
+    background-image:url(${TestImg1});
+    margin: 0 0.3rem;
+`;
+
+const BarContainer = styled.div`
+    display : flex;
+    width : 100%;
+    justify-content : center;
+    align-items : center;
+    flex-direction : column;
+    background:url(${Bar});
+`;
+
+const NowBar = styled.div`
+    width : 100%;
+    height : 5px;
+    background-size : cover;
+    background-image:url(${GreenBar});
+`;
+
+export default function Category() {
+    return (
+        <Wrapper>
+            <Grid>
+                {/* 성인 카테고리 */}
+                <Container> 
+                    <Item />
+                </Container>
+
+                {/* 키즈 카테고리 */}
+                <Container>
+                    <Item/>
+                </Container>
+            </Grid>
+
+            <Grid>
+                <BarContainer>
+                    <NowBar/>
+                </BarContainer>
+                <BarContainer>
+                    {/* <NowBar/> */}
+                </BarContainer>
+            </Grid>
+
+        </Wrapper>
+    )
+}

--- a/src/component/Category/index.js
+++ b/src/component/Category/index.js
@@ -1,0 +1,1 @@
+export {default} from './Category';

--- a/src/pages/Main/Main.js
+++ b/src/pages/Main/Main.js
@@ -3,17 +3,19 @@ import styled from 'styled-components';
 import Banner from '../../component/Banner'
 import Menu from '../../component/Menu'
 import MyCenter from '../../component/MyCenter'
+import Category from '../../component/Category'
 
 const Wrapper = styled.div`
     display:flex;
     flex-direction: column;
     width:100%;
-    margin-top: 2rem;
 `;
 
 export default function Main() {
     return (
         <Wrapper>
+            <Category />
+            
             <Banner />
            
             <Menu />

--- a/src/styles/images/CategoryBar.svg
+++ b/src/styles/images/CategoryBar.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="360" height="1" viewBox="0 0 360 1"><defs><style>.a{fill:#ededed;}</style></defs><rect class="a" width="360" height="1"/></svg>

--- a/src/styles/images/CategoryTest1.svg
+++ b/src/styles/images/CategoryTest1.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="59" height="22" viewBox="0 0 59 22"><defs><style>.a{font-size:15px;font-family:NotoSansCJKkr-Medium, Noto Sans CJK KR;font-weight:500;}</style></defs><g transform="translate(-17.5 -10.25)"><text class="a" transform="translate(17.5 27.25)"><tspan x="0" y="0">관심 강좌</tspan></text></g></svg>

--- a/src/styles/images/GreenBar.svg
+++ b/src/styles/images/GreenBar.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="180" height="1.75" viewBox="0 0 180 1.75"><defs><style>.a{fill:#11b542;}</style></defs><path class="a" d="M0,0H180V1.75H0Z"/></svg>


### PR DESCRIPTION
## What is this PR? :mag:

메인 페이지의 헤더 하단에 바로 위치하는 성인/키즈 메뉴입니다. 
바뀐 스토리 보드를 참고하였고, 아직 디자인 시안이 나오지 않아 비슷한 시안을 임시로 넣어놓았습니다.

## Changes :memo:

헤더 하단에 성인/키즈 메뉴를 추가

## Screenshot :camera:

![스크린샷 2020-09-08 오전 1 48 22](https://user-images.githubusercontent.com/53414140/92408097-75530a00-f177-11ea-8550-8c5c49e7c796.png)
